### PR TITLE
Use os.makedirs for multilevel folders

### DIFF
--- a/pipsi.py
+++ b/pipsi.py
@@ -153,7 +153,7 @@ class Repo(object):
             return
 
         if not os.path.exists(self.bin_dir):
-            os.mkdir(self.bin_dir)
+            os.makedirs(self.bin_dir)
 
         from subprocess import Popen
 


### PR DESCRIPTION
If `~/.local/bin` doesn't exist `os.mkdir` fails, because it can't create directories recursively. Use `os.makedirs` instead!
