### PR TITLE
Uses requirement parser to normalize package name.

### DIFF
--- a/pipsi.py
+++ b/pipsi.py
@@ -4,12 +4,13 @@ import shutil
 from urlparse import urlparse
 
 import click
-from pkg_resources import safe_name
+from pkg_resources import Requirement
 
 
 def normalize_package(value):
     # Strips the version and normalizes name
-    return str(safe_name(value.strip().split('=')[0]).lower())
+    requirement = Requirement.parse(value)
+    return requirement.project_name.lower()
 
 
 def real_readlink(filename):


### PR DESCRIPTION
Hi @mitsuhiko,

I found this issue by `pipsi install honcho[export]`, and the output of `pipsi list` is:

```
$ pipsi list
...
  Package "honcho-export-":
    honcho
...
```

The name `honcho-export-` is strange.

I tried to use `pkg_resources.Requirement.parse` to normalize the package names. Then the version will be striped and the name will be "safe" still, and the package names with extra requirements like `honcho[export]` could be parsed correctly now.

Could you review it? Thank you.
