### PR TITLE
Bug-fix: `rmdir` isn't a shutil function

### DIFF
--- a/get-pipsi.py
+++ b/get-pipsi.py
@@ -43,7 +43,7 @@ def main():
 
     def _cleanup():
         try:
-            shutil.rmdir(venv)
+            shutil.rmtree(venv)
         except (OSError, IOError):
             pass
 


### PR DESCRIPTION
When cleaning up, use `rmtree` to delete the pipsi venv.
