### PR TITLE
Accept Pipsi settings from environment variables

### DIFF
--- a/pipsi.py
+++ b/pipsi.py
@@ -274,9 +274,10 @@ pass_repo = click.make_pass_decorator(Repo, ensure=True)
 
 
 @click.group()
-@click.option('--home', type=click.Path(), default=None,
+@click.option('--home', type=click.Path(), default=None, envvar='PIPSI_HOME',
               help='The folder that contains the virtualenvs.')
 @click.option('--bin-dir', type=click.Path(), default=None,
+              envvar='PIPSI_BIN_DIR',
               help='The path where the scripts are symlinked to.')
 @click.version_option()
 @pass_repo


### PR DESCRIPTION
This commit allows the user to specify Pipsi defaults using environment
variables:

    --home    PIPSI_HOME
    --bin-dir PIPSI_BIN_DIR

This makes it easier to integrate Pipsi with an existing development
environment (i.e., virtualenv layout).