### PR TITLE
Read absolute paths from metadata lines

### DIFF
--- a/pipsi.py
+++ b/pipsi.py
@@ -30,7 +30,7 @@ FIND_SCRIPTS_SCRIPT = r'''if 1:
     dist = pkg_resources.get_distribution(pkg)
     if dist.has_metadata('RECORD'):
         for line in dist.get_metadata_lines('RECORD'):
-            print(line.split(',')[0])
+            print(os.path.join(dist.location, line.split(',')[0]))
     elif dist.has_metadata('installed-files.txt'):
         for line in dist.get_metadata_lines('installed-files.txt'):
             print(os.path.join(dist.egg_info, line.split(',')[0]))


### PR DESCRIPTION
Paths in metadata are relative to the distribution location. Making them absolute
prevents them from being interpreted as being relative to the current working
directory later on in find_scripts.