### PR TITLE
install: accept '-e' as alias for '--editable'

### DIFF
--- a/pipsi.py
+++ b/pipsi.py
@@ -352,7 +352,7 @@ def cli(ctx, home, bin_dir):
 @click.argument('package')
 @click.option('--python', default=None,
               help='The python interpreter to use.')
-@click.option('--editable', is_flag=True,
+@click.option('--editable/-e', is_flag=True,
               help='Enable editable installation.  This only works for '
                    'locally installed packages.')
 @click.pass_obj


### PR DESCRIPTION
`pip install -e …` is commonly used and it is confusing that `pipsi
install` would only accept `--editable`.