### PR TITLE
Fix -e option: do not add it as no-flag's name

### DIFF
--- a/pipsi.py
+++ b/pipsi.py
@@ -352,7 +352,7 @@ def cli(ctx, home, bin_dir):
 @click.argument('package')
 @click.option('--python', default=None,
               help='The python interpreter to use.')
-@click.option('--editable/-e', is_flag=True,
+@click.option('--editable', '-e', is_flag=True,
               help='Enable editable installation.  This only works for '
                    'locally installed packages.')
 @click.pass_obj
@@ -372,7 +372,7 @@ def install(repo, package, python, editable):
 
 @cli.command()
 @click.argument('package')
-@click.option('--editable', is_flag=True,
+@click.option('--editable', '-e', is_flag=True,
               help='Enable editable installation.  This only works for '
                    'locally installed packages.')
 @click.pass_obj


### PR DESCRIPTION
af240ef (#53) did not add the "-e" alias for "--editable" correctly.

This patch fixes it, and also adds it for `upgrade`.