### PR TITLE
Fix `pipsi list` when ~/.local is a symlink

### DIFF
--- a/pipsi.py
+++ b/pipsi.py
@@ -311,21 +311,7 @@ class Repo(object):
             venv_path = os.path.join(self.home, venv)
             if os.path.isdir(venv_path) and \
                os.path.isfile(venv_path + python):
-                venvs[venv] = []
-
-        def _find_venv(target):
-            for venv in venvs:
-                if target.startswith(join(self.home, venv, '')):
-                    return venv
-
-        for script in os.listdir(self.bin_dir):
-            exe = os.path.join(self.bin_dir, script)
-            target = real_readlink(exe)
-            if target is None:
-                continue
-            venv = _find_venv(target)
-            if venv is not None:
-                venvs[venv].append(script)
+                venvs[venv] = list(self.find_installed_executables(venv_path))
 
         return sorted(venvs.items())
 


### PR DESCRIPTION
`pipsi list` would produce an empty list when ~/.local was a symlink to
another directory. This was because the comparison between binary paths
and venv paths was using dereferenced paths for the binaries but
non-dereferenced paths for the venvs. There's already a perfectly-good
function in the code that does this operation correctly,
`Repo.find_installed_executables()`, so `Repo.list_everything()` can
just use that instead.