### PR TITLE
defend against truncation attacks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ How do I get it?
 
 ::
 
-    curl https://raw.githubusercontent.com/mitsuhiko/pipsi/master/get-pipsi.py | python
+    curl -O https://raw.githubusercontent.com/mitsuhiko/pipsi/master/get-pipsi.py && python get-pipsi.py
 
 How does it work?
 


### PR DESCRIPTION
Consider the example of this snippet:

```
rm -fr /tmp/foo
```

If someone can introduce an EOF right after the first slash, this changes the meaning of the shell script considerably.  There are similar (although harder to construct) examples for Python.  So, don't ever pipe stuff directly from `curl` without fully downloading it first.