### PR TITLE
pipsi-66 pips fails on `list` when nothing installed

### DIFF
--- a/pipsi.py
+++ b/pipsi.py
@@ -307,11 +307,12 @@ class Repo(object):
     def list_everything(self):
         venvs = {}
         python = '/Scripts/python.exe' if IS_WIN else '/bin/python'
-        for venv in os.listdir(self.home):
-            venv_path = os.path.join(self.home, venv)
-            if os.path.isdir(venv_path) and \
-               os.path.isfile(venv_path + python):
-                venvs[venv] = list(self.find_installed_executables(venv_path))
+        if os.path.isdir(self.home):
+            for venv in os.listdir(self.home):
+                venv_path = os.path.join(self.home, venv)
+                if os.path.isdir(venv_path) and \
+                   os.path.isfile(venv_path + python):
+                    venvs[venv] = list(self.find_installed_executables(venv_path))
 
         return sorted(venvs.items())
 
@@ -404,13 +405,17 @@ def uninstall(repo, package, yes):
 @click.pass_obj
 def list_cmd(repo):
     """Lists all scripts installed through pipsi."""
-    click.echo('Packages and scripts installed through pipsi:')
-    for venv, scripts in repo.list_everything():
-        if not scripts:
-            continue
-        click.echo('  Package "%s":' % venv)
-        for script in scripts:
-            click.echo('    ' + script)
+    list_of_non_empty_venv = [(venv, scripts)
+                              for venv, scripts in repo.list_everything()
+                              if scripts]
+    if list_of_non_empty_venv:
+        click.echo('Packages and scripts installed through pipsi:')
+        for venv, scripts in list_of_non_empty_venv:
+            click.echo('  Package "%s":' % venv)
+            for script in scripts:
+                click.echo('    ' + script)
+    else:
+        click.echo('There are no scripts installed through pipsi')
 
 if __name__ == '__main__':
     cli()

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -1,0 +1,16 @@
+import pytest
+
+
+@pytest.fixture(params=['normal', 'MixedCase'])
+def mix(request):
+    return request.param
+
+
+@pytest.fixture
+def bin(tmpdir, mix):
+    return tmpdir.ensure(mix, 'bin', dir=1)
+
+
+@pytest.fixture
+def home(tmpdir, mix):
+    return tmpdir.ensure(mix, 'venvs', dir=1)

--- a/testing/test_command_line.py
+++ b/testing/test_command_line.py
@@ -1,0 +1,13 @@
+import subprocess
+
+import pytest
+import sys
+
+
+@pytest.mark.usefixtures("home")
+def test_list_command(home):
+    assert not home.listdir()
+    output = subprocess.check_output([
+        sys.executable, 'pipsi.py', '--home', home.strpath, 'list'
+    ])
+    assert output == 'There are no scripts installed through pipsi\n'

--- a/testing/test_command_line.py
+++ b/testing/test_command_line.py
@@ -4,7 +4,6 @@ import pytest
 import sys
 
 
-@pytest.mark.usefixtures("home")
 def test_list_command(home):
     assert not home.listdir()
     output = subprocess.check_output([

--- a/testing/test_repo.py
+++ b/testing/test_repo.py
@@ -4,9 +4,6 @@ import pytest
 from pipsi import Repo, find_scripts
 
 
-pytestmark = pytest.mark.usefixtures("home", "bin", "mix")
-
-
 @pytest.fixture
 def repo(home, bin):
     return Repo(str(home), str(bin))

--- a/testing/test_repo.py
+++ b/testing/test_repo.py
@@ -4,19 +4,7 @@ import pytest
 from pipsi import Repo, find_scripts
 
 
-@pytest.fixture(params=['normal', 'MixedCase'])
-def mix(request):
-    return request.param
-
-
-@pytest.fixture
-def bin(tmpdir, mix):
-    return tmpdir.ensure(mix, 'bin', dir=1)
-
-
-@pytest.fixture
-def home(tmpdir, mix):
-    return tmpdir.ensure(mix, 'venvs', dir=1)
+pytestmark = pytest.mark.usefixtures("home", "bin", "mix")
 
 
 @pytest.fixture
@@ -40,6 +28,12 @@ def test_simple_install(repo, home, bin, package, glob):
                    reason='attic is python3 only')
 def test_simple_install_attic(repo, home, bin):
     test_simple_install(repo, home, bin, 'attic', 'attic*')
+
+
+def test_list_everything(repo, home, bin):
+    assert not home.listdir()
+    assert not bin.listdir()
+    assert repo.list_everything() == []
 
 
 def test_find_scripts():


### PR DESCRIPTION
will output: 'There are no scripts installed through pipsi' instead of the traceback
