### PR TITLE
Make pipsi rely on its own copy of virtualenv after installation

### DIFF
--- a/pipsi.py
+++ b/pipsi.py
@@ -230,7 +230,7 @@ class Repo(object):
             return False
 
         # Install virtualenv, use the pipsi used python version by default
-        args = ['virtualenv', '-p', python or sys.executable, venv_path]
+        args = [sys.executable, '-m', 'virtualenv', '-p', python or sys.executable, venv_path]
 
         if system_site_packages:
             args.append('--system-site-packages')


### PR DESCRIPTION
Fixes #75
