### PR TITLE
Use realpath() for 'home' prefix

### DIFF
--- a/pipsi.py
+++ b/pipsi.py
@@ -156,7 +156,7 @@ class UninstallInfo(object):
 class Repo(object):
 
     def __init__(self, home, bin_dir):
-        self.home = home
+        self.home = realpath(home)
         self.bin_dir = bin_dir
 
     def resolve_package(self, spec, python=None):


### PR DESCRIPTION
If 'home' directory (or any of its parents) is a symbolic link, path
comparisons for finding virtualenvs must use the real path otherwise
they will never match (listings will produce no results).
