### PR TITLE
Fix path display on Windows

### DIFF
--- a/pipsi/__init__.py
+++ b/pipsi/__init__.py
@@ -369,12 +369,12 @@ class Repo(object):
 @click.group(context_settings=CONTEXT_SETTINGS)
 @click.option(
     '--home', type=click.Path(),envvar='PIPSI_HOME',
-    default=os.path.expanduser('~/.local/venvs'),
+    default=os.path.join(os.path.expanduser('~'), '.local', 'venvs'),
     help='The folder that contains the virtualenvs.')
 @click.option(
     '--bin-dir', type=click.Path(),
     envvar='PIPSI_BIN_DIR',
-    default=os.path.expanduser('~/.local/bin'),
+    default=os.path.join(os.path.expanduser('~'), '.local', 'bin'),
     help='The path where the scripts are symlinked to.')
 
 @click.version_option(


### PR DESCRIPTION
Use the appropriate sep on the OS instead of always '/'

This deals with awkward displays on Windows such as

```
Installing collected packages: mccabe, pycodestyle, pyflakes, flake8
Successfully installed flake8-3.4.1 mccabe-0.6.1 pycodestyle-2.3.1 pyflakes-1.5.0
  Copied Executable C:\Users\uranusjr/.local/bin\flake8.exe
Done.
```