### PR TITLE
Use matrix build for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,20 @@
 language: python
-python:
-    - "2.6"
-    - "2.7"
-    - "pypy"
-    - "3.3"
-    - "3.4"
+matrix:
+  include:
+    - env: TOXENV=py26
+      python: "2.6"
+    - env: TOXENV=py27
+      python: "2.7"
+    - env: TOXENV=pypy
+      python: "pypy"
+    - env: TOXENV=py33
+      python: "3.3"
+    - env: TOXENV=py34
+      python: "3.4"
+    - env: TOXENV=py35
+      python: "3.5"
+    - env: TOXENV=py36
+      python: "3.6"
 
 install: pip install tox
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
 matrix:
   include:
-    - env: TOXENV=py26
-      python: "2.6"
     - env: TOXENV=py27
       python: "2.7"
     - env: TOXENV=pypy


### PR DESCRIPTION
The current approach of just having multiple Python elements fails, because Travis puts each Python installation into its own private virtualenv. As a result, tox can't see them all, and so fails.

This PR changes Travis to use a "matrix" build - each Python version is run as a separate build, and tox is run in each, with `TOXENV` set to that Python version.

I took the liberty of adding Python 3.5 and 3.6 to the test matrix. Also, the tests fail on Python 2,6, because `subprocess.check_output` doesn't exist in that version. It's probably possible to fix that, but I don't know if `pipsi` formally supports Python 2.6. Personally, I'm inclined not to do so, but that's not really my call.