### PR TITLE
Improve error handling for local installs

### DIFF
--- a/pipsi/__init__.py
+++ b/pipsi/__init__.py
@@ -168,12 +168,18 @@ class Repo(object):
         else:
             return spec, [spec]
 
+        if not os.path.exists(join(location, 'setup.py')):
+            raise click.UsageError('%s does not appear to be a local '
+                                   'Python package.' % spec)
+
         error, name, errmsg = statusoutput(
             [python or sys.executable, 'setup.py', '--name'],
             cwd=location)
         if error:
-            raise click.UsageError('%s does not appear to be a local '
-                                   'Python package.' % spec)
+            raise click.UsageError(
+                '%s does not appear to be a valid '
+                'package. Error from setup.py: %s' % (spec, errmsg)
+            )
 
         return name, [location]
 

--- a/testing/test_repo.py
+++ b/testing/test_repo.py
@@ -1,12 +1,49 @@
 import os
 import sys
 import pytest
+import click
 from pipsi import Repo, find_scripts
 
 
 @pytest.fixture
 def repo(home, bin):
     return Repo(str(home), str(bin))
+
+
+@pytest.mark.resolve
+def test_resolve_local_package(repo, tmpdir):
+    pkgdir = tmpdir.ensure('foopkg', dir=True)
+    pkgdir.join('setup.py').write_text(
+        u'\n'.join([
+            u'from setuptools import setup',
+            u'setup(name="foopkg", version="0.0.1", py_modules=["foo"])'
+        ]),
+        'utf-8'
+    )
+    pkgdir.join('foo.py').write_text(u'print("hello world")\n', 'utf-8')
+
+    assert repo.resolve_package(str(pkgdir)) == ('foopkg', [str(pkgdir)])
+
+
+@pytest.mark.resolve
+def test_resolve_local_fails_when_invalid_package(repo, tmpdir):
+    pkgdir = tmpdir.ensure('foopkg', dir=True)
+    pkgdir.join('setup.py').write_text(u'raise Exception("EXCMSG")', 'utf-8')
+    pkgdir.join('foo.py').ensure()
+
+    with pytest.raises(click.UsageError) as excinfo:
+        repo.resolve_package(str(pkgdir))
+    assert 'does not appear to be a valid package' in str(excinfo.value)
+    assert 'EXCMSG' in str(excinfo.value)
+
+
+@pytest.mark.resolve
+def test_resolve_local_fails_when_no_package(repo, tmpdir):
+    pkgdir = tmpdir.ensure('foopkg', dir=True)
+
+    with pytest.raises(click.UsageError) as excinfo:
+        repo.resolve_package(str(pkgdir))
+    assert 'does not appear to be a local Python package' in str(excinfo.value)
 
 
 @pytest.mark.parametrize('package, glob', [


### PR DESCRIPTION
[![Review](https://codenvy.io/factory/resources/factory-review.svg)](https://codenvy.io/f?id=factoryt1mykjp5pl45sw81)

Distinguish between non-packages and invalid setup.py.

Slight refactor of `statusoutput` necessary to get access to error output from subprocess that runs `setup.py`.

Close #101
