### PR TITLE
Prefer venv over virtualenv if present

### DIFF
--- a/get-pipsi.py
+++ b/get-pipsi.py
@@ -19,14 +19,14 @@ else:
     PIPSI = '/Scripts/pipsi.exe'
 
 try:
-    import virtualenv
-    venv_pkg = 'virtualenv'
-    del virtualenv
+    import venv
+    venv_pkg = 'venv'
+    del venv
 except ImportError:
     try:
-        import venv
-        venv_pkg = 'venv'
-        del venv
+        import virtualenv
+        venv_pkg = 'virtualenv'
+        del virtualenv
     except ImportError:
         venv_pkg = None
 

--- a/pipsi/__init__.py
+++ b/pipsi/__init__.py
@@ -8,6 +8,21 @@ import glob
 from collections import namedtuple
 from os.path import join, realpath, dirname, normpath, normcase
 from operator import methodcaller
+
+
+try:
+    import venv
+    venv_pkg = 'venv'
+    del venv
+except ImportError:
+    try:
+        import virtualenv
+        venv_pkg = 'virtualenv'
+        del virtualenv
+    except ImportError:
+        venv_pkg = None
+
+
 try:
     subprocess.run
 
@@ -270,7 +285,7 @@ class Repo(object):
             return False
 
         # Install virtualenv, use the pipsi used python version by default
-        args = [sys.executable, '-m', 'virtualenv', '-p', python or sys.executable, venv_path]
+        args = [sys.executable, '-m', venv_pkg, '-p', python or sys.executable, venv_path]
 
         if system_site_packages:
             args.append('--system-site-packages')

--- a/pipsi/__init__.py
+++ b/pipsi/__init__.py
@@ -285,7 +285,11 @@ class Repo(object):
             return False
 
         # Install virtualenv, use the pipsi used python version by default
-        args = [sys.executable, '-m', venv_pkg, '-p', python or sys.executable, venv_path]
+        if venv_pkg == 'venv':
+            args = [sys.executable, '-m', venv_pkg, venv_path]
+        else:
+            args = [sys.executable, '-m', venv_pkg, '-p', python or sys.executable, venv_path]
+
 
         if system_site_packages:
             args.append('--system-site-packages')

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'Click',
-        'virtualenv',
+        'virtualenv;python_version<"3.0"',
     ],
     entry_points='''
     [console_scripts]


### PR DESCRIPTION
`virtualenv` doesn't seem to work properly in Python 3.6, which causes
the issue documented in #118. Preferring `venv` fixes that issue.