### PR TITLE
make sure pipsi venv gets created with correct python version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build
 .tox/
 .env/
 .cache/
+.pytest_cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ matrix:
       python: "2.7"
     - env: TOXENV=pypy
       python: "pypy"
-    - env: TOXENV=py33
-      python: "3.3"
     - env: TOXENV=py34
       python: "3.4"
     - env: TOXENV=py35

--- a/get-pipsi.py
+++ b/get-pipsi.py
@@ -82,7 +82,12 @@ def install_files(venv, bin_dir, install):
         except (OSError, IOError):
             pass
 
-    if call([sys.executable, '-m', venv_pkg, venv]) != 0:
+    venv_cmd = [sys.executable, '-m', venv_pkg]
+    if venv_pkg == 'virtualenv':
+        venv_cmd += ['-p', sys.executable]
+    venv_cmd += [venv]
+
+    if call(venv_cmd) != 0:
         _cleanup()
         fail('Could not create virtualenv for pipsi :(')
 

--- a/testing/test_install_script.py
+++ b/testing/test_install_script.py
@@ -1,3 +1,4 @@
+import os.path
 import sys
 import subprocess
 from pipsi import IS_WIN
@@ -11,11 +12,10 @@ def test_create_env(tmpdir):
         '--src', '.',
         '--ignore-existing',
     ])
-    if IS_WIN:
-        subprocess.check_call([
-            str(tmpdir.join('test_bin/pipsi.exe'))
-        ])
-    else:
-        subprocess.check_call([
-            str(tmpdir.join('test_bin/pipsi'))
-        ])
+    pipsi_bin = str(tmpdir.join('test_bin/pipsi' + ('.exe' if IS_WIN else '')))
+
+    subprocess.check_call([pipsi_bin])
+
+    python = os.path.basename(sys.executable)
+    version_out = subprocess.check_output([pipsi_bin, '--version'])
+    assert version_out.strip().endswith(python), '%r'

--- a/testing/test_install_script.py
+++ b/testing/test_install_script.py
@@ -17,5 +17,6 @@ def test_create_env(tmpdir):
     subprocess.check_call([pipsi_bin])
 
     python = os.path.basename(sys.executable)
-    version_out = subprocess.check_output([pipsi_bin, '--version'])
-    assert version_out.strip().endswith(python), '%r'
+    version_out = subprocess.check_output([pipsi_bin, '--version']).decode()
+    assert version_out.strip().endswith(python), \
+        '%r does not end with %r' % (version_out, python)


### PR DESCRIPTION
Currently, if you run `get-pipsi.py` with python3, it'll still get installed with python2 in some cases.

The reason for this is that if you run this command:

    python3 -m virtualenv path/to/venv

It will actually create a python 2 virtualenv. When using the `virtualenv` command, you have to specify the python binary to use manually with `-p`.

Fixes #132