### PR TITLE
Do "python -m pip install" instead of "pip install"

### DIFF
--- a/pipsi/__init__.py
+++ b/pipsi/__init__.py
@@ -280,7 +280,7 @@ class Repo(object):
                 click.echo('Failed to create virtualenv.  Aborting.')
                 return _cleanup()
 
-            args = [os.path.join(venv_path, BIN_DIR, 'pip'), 'install']
+            args = [os.path.join(venv_path, BIN_DIR, 'python'), '-m', 'pip', 'install']
             if editable:
                 args.append('--editable')
 


### PR DESCRIPTION
This prevents Windows from erroring if the package to install contains a dependency to pip. On Windows you can’t write to a running executable so `pip install -U pip` will fail. The official solution is to do `python -m pip install -U pip` instead.