### PR TITLE
Run pip via 'python -m pip' so it can upgrade itself

### DIFF
--- a/pipsi/__init__.py
+++ b/pipsi/__init__.py
@@ -280,7 +280,7 @@ class Repo(object):
                 click.echo('Failed to create virtualenv.  Aborting.')
                 return _cleanup()
 
-            args = [os.path.join(venv_path, BIN_DIR, 'pip'), 'install']
+            args = [os.path.join(venv_path, BIN_DIR, 'python'), '-m', 'pip', 'install']
             if editable:
                 args.append('--editable')
 
@@ -325,7 +325,7 @@ class Repo(object):
 
         old_scripts = set(self.get_package_scripts(venv_path))
 
-        args = [os.path.join(venv_path, BIN_DIR, 'pip'), 'install',
+        args = [os.path.join(venv_path, BIN_DIR, 'python'), '-m', 'pip', 'install',
                 '--upgrade']
         if editable:
             args.append('--editable')


### PR DESCRIPTION
On Windows, `pip install --upgrade pip` will fail, as it tries to replace the `pip.exe` executable used to run pip (and it can't because that file is in use).

This PR calls pip using the command `python -m pip`, which avoids the executable wrapper and so allows projects that have pip as a dependency (such as pipenv) to be managed by pipsi.