### PR TITLE
auto add bin dir to PATH of shell config (i.e. .bashrc)

### DIFF
--- a/get-pipsi.py
+++ b/get-pipsi.py
@@ -123,6 +123,11 @@ def parse_options(argv):
         ),
     )
     parser.add_argument(
+        '--no-modify-path',
+        action='store_true',
+        help='Don\'t configure the PATH environment variable'
+    )
+    parser.add_argument(
         '--ignore-existing',
         action='store_true',
         help=(
@@ -133,7 +138,7 @@ def parse_options(argv):
     return parser.parse_args(argv)
 
 
-def ensure_pipsi_on_path(bin_dir):
+def ensure_pipsi_on_path(bin_dir, modify_path):
     if not command_exists('pipsi'):
         shell = os.environ.get('SHELL', '')
         if 'bash' in shell:
@@ -145,7 +150,7 @@ def ensure_pipsi_on_path(bin_dir):
         else:
             config_file = None
 
-        if os.path.exists(config_file):
+        if modify_path and os.path.exists(config_file):
             with open(config_file, 'a') as f:
                 f.write('\n# added by pipsi\n')
                 f.write('export PATH="%s:$PATH"\n\n' % bin_dir)
@@ -159,10 +164,10 @@ def ensure_pipsi_on_path(bin_dir):
                 '''
                 %(sep)s
 
-                Warning:
-                  It looks like %(bin_dir)s is not on your PATH so pipsi will not
-                  work out of the box. To fix this problem make sure to add this to
-                  your .bashrc / .profile file:
+                Note:
+                  To finish installation, %(bin_dir)s must be added to your PATH.
+                  This can be done by adding the following line to your shell
+                  config file:
 
                   export PATH=%(bin_dir)s:$PATH
 
@@ -177,7 +182,7 @@ def main(argv=sys.argv[1:]):
     if command_exists('pipsi') and not args.ignore_existing:
         succeed('You already have pipsi installed')
     elif os.path.exists(os.path.join(args.bin_dir, 'pipsi')):
-        ensure_pipsi_on_path(args.bin_dir)
+        ensure_pipsi_on_path(args.bin_dir, not args.no_modify_path)
         succeed('pipsi is now installed')
     else:
         echo('Installing pipsi')
@@ -187,7 +192,7 @@ def main(argv=sys.argv[1:]):
 
     venv = os.path.join(args.home_dir, 'pipsi')
     install_files(venv, args.bin_dir, args.src)
-    ensure_pipsi_on_path(args.bin_dir)
+    ensure_pipsi_on_path(args.bin_dir, not args.no_modify_path)
     succeed('pipsi is now installed.')
 
 

--- a/get-pipsi.py
+++ b/get-pipsi.py
@@ -135,19 +135,19 @@ def parse_options(argv):
 
 def ensure_pipsi_on_path(bin_dir):
     if not command_exists('pipsi'):
-        config_files = [
-            os.path.expanduser('~/.bashrc'),
-            os.path.expanduser('~/.profile'),
-        ]
-        config_file = None
-        for f in config_files:
-            if os.path.exists(f):
-                config_file = f
-                break
+        shell = os.environ.get('SHELL', '')
+        if 'bash' in shell:
+            config_file = os.path.expanduser('~/.bashrc')
+        elif 'zsh' in shell:
+            config_file = os.path.expanduser('~/.zshrc')
+        elif 'fish' in shell:
+            config_file = os.path.expanduser('~/.config/fish/config.fish')
+        else:
+            config_file = None
 
-        if config_file:
+        if os.path.exists(config_file):
             with open(config_file, 'a') as f:
-                f.write('\n# This line added by pipsi\n')
+                f.write('\n# added by pipsi\n')
                 f.write('export PATH="%s:$PATH"\n\n' % bin_dir)
             echo(
                 'Added %s to the PATH environment variable in %s' %

--- a/get-pipsi.py
+++ b/get-pipsi.py
@@ -142,18 +142,24 @@ def ensure_pipsi_on_path(bin_dir, modify_path):
     if not command_exists('pipsi'):
         shell = os.environ.get('SHELL', '')
         if 'bash' in shell:
-            config_file = os.path.expanduser('~/.bashrc')
+            config_file = '~/.bashrc'
         elif 'zsh' in shell:
-            config_file = os.path.expanduser('~/.zshrc')
+            config_file = '~/.zshrc'
         elif 'fish' in shell:
-            config_file = os.path.expanduser('~/.config/fish/config.fish')
+            config_file = '~/.config/fish/config.fish'
         else:
             config_file = None
+
+        if config_file:
+            config_file = os.path.expanduser(config_file)
 
         if modify_path and os.path.exists(config_file):
             with open(config_file, 'a') as f:
                 f.write('\n# added by pipsi\n')
-                f.write('export PATH="%s:$PATH"\n\n' % bin_dir)
+                if 'fish' in shell:
+                    f.write('set -x PATH %s $PATH\n\n' % bin_dir)
+                else:
+                    f.write('export PATH="%s:$PATH"\n\n' % bin_dir)
             echo(
                 'Added %s to the PATH environment variable in %s' %
                 (bin_dir, config_file)

--- a/get-pipsi.py
+++ b/get-pipsi.py
@@ -155,11 +155,11 @@ def ensure_pipsi_on_path(bin_dir, modify_path):
 
         if modify_path and os.path.exists(config_file):
             with open(config_file, 'a') as f:
-                f.write('\n# added by pipsi\n')
+                f.write('\n# added by pipsi (https://github.com/mitsuhiko/pipsi)\n')
                 if 'fish' in shell:
                     f.write('set -x PATH %s $PATH\n\n' % bin_dir)
                 else:
-                    f.write('export PATH="%s:$PATH"\n\n' % bin_dir)
+                    f.write('export PATH="%s:$PATH"\n' % bin_dir)
             echo(
                 'Added %s to the PATH environment variable in %s' %
                 (bin_dir, config_file)
@@ -190,9 +190,8 @@ def main(argv=sys.argv[1:]):
     elif os.path.exists(os.path.join(args.bin_dir, 'pipsi')):
         ensure_pipsi_on_path(args.bin_dir, not args.no_modify_path)
         succeed('pipsi is now installed')
-    else:
-        echo('Installing pipsi')
 
+    echo('Installing pipsi')
     if venv_pkg is None:
         fail('You need to have virtualenv installed to bootstrap pipsi.')
 

--- a/get-pipsi.py
+++ b/get-pipsi.py
@@ -175,7 +175,6 @@ def main(argv=sys.argv[1:]):
     args = parse_options(argv)
 
     if command_exists('pipsi') and not args.ignore_existing:
-        ensure_pipsi_on_path(args.bin_dir)
         succeed('You already have pipsi installed')
     elif os.path.exists(os.path.join(args.bin_dir, 'pipsi')):
         ensure_pipsi_on_path(args.bin_dir)


### PR DESCRIPTION
* automate the manipulation of shell config file (ie bashrc)
* handle case where user tries to re-install pipsi because it's not on the PATH, but already exists on disk (this previously resulted in a bare python exception being raised)
* add flag to skip path manipulation 