### PR TITLE
Always decode proc_output from UTF-8 on Python 2

### DIFF
--- a/pipsi/__init__.py
+++ b/pipsi/__init__.py
@@ -53,7 +53,7 @@ CONTEXT_SETTINGS = dict(
 
 def proc_output(s):
     s = s.strip()
-    if not isinstance(s, str):
+    if  isinstance(s, bytes):
         s = s.decode('utf-8', 'replace')
     return s
 


### PR DESCRIPTION
proc_output only decoded from UTF-8 if the input string was not
an instance of `str`. This seems to be for Python >=3.5 as the the
type of stdout returned by subprocess.run(...) is `bytes` not `str`.
In Python 2 a series of bytes is represented by the `str` type and
not a separate `bytes` type, so the output of subprocess.Popen will
be of type `str` but this is really a series of bytes representing
a string in some encoding. Fortunately in Python 2 `bytes` is an
alias for `str` so proc_output can change to decode when it receives
`bytes`.

For complete correctness proc_output should decode with the encoding
of the bytes in the output these suggest that the decoding to use
is the result of os.getfilesystemencoding():
    
https://github.com/pyinstaller/pyinstaller/issues/1325
https://bugs.python.org/issue19846
    
However, other parts of pipsi assume UTF-8 encoding (it is a safe
default) so proc_output has been left to assume UTF-8.

Fixes #133