### PR TITLE
remove python 3.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ matrix:
       python: "2.7"
     - env: TOXENV=pypy
       python: "pypy"
-    - env: TOXENV=py33
-      python: "3.3"
     - env: TOXENV=py34
       python: "3.4"
     - env: TOXENV=py35

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         'Click',
         'virtualenv',
     ],
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     entry_points='''
     [console_scripts]
     pipsi=pipsi:cli


### PR DESCRIPTION
wheel and pip no longer support python 3.3 (#152)

![image](https://user-images.githubusercontent.com/5715368/40692099-9f5bc556-6364-11e8-951b-07170e9c9ca6.png)
