### PR TITLE
Feature/improve package info handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build
 .env/
 .cache/
 .pytest_cache/
+Pipfile

--- a/get-pipsi.py
+++ b/get-pipsi.py
@@ -95,7 +95,12 @@ def install_files(venv, bin_dir, install):
         _cleanup()
         fail('Could not create virtualenv for pipsi :(')
 
-    if call([venv + PIP, 'install', install]) != 0:
+    install_cmd = [venv + PIP, 'install']
+    # add -e, --editable for installing from current directory, for dev purpose only
+    if install == '.':
+        install_cmd.append('-e')
+    install_cmd.append(install)
+    if call(install_cmd) != 0:
         _cleanup()
         fail('Could not install pipsi :(')
 

--- a/pipsi/__init__.py
+++ b/pipsi/__init__.py
@@ -281,6 +281,9 @@ class Repo(object):
         return self.find_installed_executables(path)
 
     def link_scripts(self, scripts):
+        """Link venv script path to bin dir,
+        returns list of tuple of (venv script path, bin dir symlink path)
+        """
         rv = []
         for script in scripts:
             script_dst = os.path.join(
@@ -310,7 +313,7 @@ class Repo(object):
         o = {
             'name': package_name,
             'version': version,
-            'scripts': [script for target, script in scripts],
+            'scripts': scripts,
         }
         return o
 
@@ -394,7 +397,7 @@ class Repo(object):
         # And link them
         linked_scripts = self.link_scripts(scripts)
 
-        self.save_package_info(venv_path, package, linked_scripts)
+        self.save_package_info(venv_path, package, [i[1] for i in linked_scripts])
 
         # We did not link any, rollback.
         if not linked_scripts:
@@ -433,7 +436,7 @@ class Repo(object):
 
         scripts = find_scripts(venv_path, package)
         linked_scripts = self.link_scripts(scripts)
-        to_delete = old_scripts - set(script for target, script in linked_scripts)
+        to_delete = old_scripts - set(i[1] for i in linked_scripts)
 
         for script in to_delete:
             try:

--- a/pipsi/__init__.py
+++ b/pipsi/__init__.py
@@ -542,13 +542,13 @@ def list_cmd(repo, versions):
                               if scripts]
     if list_of_non_empty_venv:
         click.echo('Packages and scripts installed through pipsi:')
-        for venv, (scripts, version) in repo.list_everything(versions):
+        for venv, (scripts, version) in list_of_non_empty_venv:
             if versions:
                 click.echo('  Package "%s" (%s):' % (venv, version or 'unknown'))
             else:
                 click.echo('  Package "%s":' % venv)
-                for script in scripts:
-                    click.echo('    ' + script)
+            for script in scripts:
+                click.echo('    ' + script)
     else:
         click.echo('There are no scripts installed through pipsi')
 

--- a/pipsi/__init__.py
+++ b/pipsi/__init__.py
@@ -18,6 +18,7 @@ try:
         kw.update(stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         r = subprocess.run(*args, **kw)
         r.stdout, r.stderr = map(proc_output, (r.stdout, r.stderr))
+        debugp('[run] argv={} code={} stdout={} stderr={}'.format(args, r.returncode, r.stdout, r.stderr))
         return r
 except AttributeError:  # no `subprocess.run`, py < 3.5
     CompletedProcess = namedtuple('CompletedProcess',
@@ -27,7 +28,9 @@ except AttributeError:  # no `subprocess.run`, py < 3.5
         p = subprocess.Popen(
             argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE, **kw)
         out, err = map(proc_output, p.communicate())
-        return CompletedProcess(argv, p.returncode, out, err)
+        cp = CompletedProcess(argv, p.returncode, out, err)
+        debugp('[run] argv={} code={} stdout={} stderr={}'.format(argv, p.returncode, out, err))
+        return cp
 try:
     from urlparse import urlparse
 except ImportError:

--- a/pipsi/__init__.py
+++ b/pipsi/__init__.py
@@ -391,22 +391,29 @@ class Repo(object):
             return _cleanup()
         return True
 
+    def check_package_installed(self, package, venv_path, echo=False):
+        if not os.path.isdir(venv_path):
+            if echo:
+                click.echo('%s is not installed' % package)
+            return False
+        return True
+
     def uninstall(self, package):
         path = self.get_package_path(package)
-        info = self.get_package_info(path)
-        if not os.path.isdir(path):
+        if not self.check_package_installed(package, path):
             return UninstallInfo(package, installed=False)
-        paths = [path]
-        paths.extend(info.get('scripts', []))
+
+        info = self.get_package_info(path)
+        paths = [path] + info.get('scripts', [])
         return UninstallInfo(package, paths)
 
     def upgrade(self, package, editable=False):
         package, install_args = self.resolve_package(package)
 
         venv_path = self.get_package_path(package)
-        if not os.path.isdir(venv_path):
-            click.echo('%s is not installed' % package)
+        if not self.check_package_installed(package, venv_path, echo=True):
             return
+
         info = self.get_package_info(venv_path)
 
         from subprocess import Popen

--- a/uninstall-pipsi.py
+++ b/uninstall-pipsi.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+
+# `which pipsi`:
+# > /Users/me/.local/bin/pipsi
+# `ls -l $(which pipsi)`:
+# > /Users/me/.local/venvs/pipsi/bin/pipsi
+
+from __future__ import print_function
+import os
+import sys
+import shutil
+
+
+PY2 = sys.version_info.major == 2
+
+
+if PY2:
+    from distutils.spawn import find_executable as which
+else:
+    from shutil import which
+
+
+def main():
+    while True:
+        pipsi_path = which('pipsi')
+        if not pipsi_path:
+            break
+        if os.path.islink(pipsi_path):
+            pipsi_real = os.path.realpath(pipsi_path)
+            venv_path = os.path.dirname(os.path.dirname(pipsi_real))
+            hint = ('pipsi real path is {}, suggest venv path is {}\n'
+                    'Delete dir {}? (y to confirm) ').format(
+                        pipsi_real, venv_path, venv_path)
+            r = raw_input(hint)
+            if r != 'y':
+                print('Deleting file {}, ignore dir {}'.format(pipsi_real, venv_path))
+                os.remove(pipsi_real)
+            else:
+                print('Deleting dir {}'.format(venv_path))
+                shutil.rmtree(venv_path)
+            print('Deleting symlink {}'.format(pipsi_path))
+            os.remove(pipsi_path)
+        else:
+            # just rm
+            print('Deleting file {}'.format(pipsi_path))
+            os.remove(pipsi_path)
+        print()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Goals:
- Fix the problem of #124
- Improve package_info related code (involved in #78), make the code more robust and easier to read, add comments to important functions, improve function consistency.

re-org the relationship of the functions below:
- save_package_info: receives data from installation process, use `make_package_info` to create the dict, save it to file
- make_package_info: in charge of creating the package_info dict from scratch
- get_package_info: if the json file exists, get and parse its data; if not, call `make_package_info` to get the dict

Eventually, `get_package_info`'s behavior becomes consistent and predictable, so now we can use it in `list_everything` easily and intuitively.

Other changes:
- Add an `uninstall-pipsi.py` script
- Add `-e` to pip when running `get-pipsi.py .`
- Fix duplicate `list_everything` call

TODO:
- [ ] Define a class to handle read/write about package_info