### PR TITLE
Better fallbacks

### DIFF
--- a/pipsi/__init__.py
+++ b/pipsi/__init__.py
@@ -290,7 +290,7 @@ class Repo(object):
         try:
             with open(package_info_file_path, 'r') as fh:
                 info = json.load(fh)
-        except OSError:
+        except (OSError, IOError):
             info = {}
 
         if 'name' not in info:

--- a/pipsi/__init__.py
+++ b/pipsi/__init__.py
@@ -300,7 +300,7 @@ class Repo(object):
             info['version'] = extract_package_version(venv_path, info['name'])
 
         if 'scripts' not in info:
-            info['scripts'] = find_installed_executables(venv_path)
+            info['scripts'] = list(self.find_installed_executables(venv_path))
 
         return info
 


### PR DESCRIPTION
Since get-pipsi.py doesn't create a `package_info.json` file, `pipsi list` will currently result in an error when pipsi is installed from master.  This PR fixes that bug, as well as generally improving pipsi's package_info fallbacks.  See 749c46c for more info.

I didn't bother to make get-pipsi.py actually create the package info file, but it might make sense to do that as well at some point.