### PR TITLE
Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,3 @@
+# Security
+
+Report vulnerabilities at https://github.com/mitsuhiko/pipsi/security/advisories


### PR DESCRIPTION
## Summary
Adds SECURITY.md with vulnerability reporting instructions.

## Why
- Enables GitHub's private vulnerability reporting  
- Helps security researchers report issues responsibly

---
*Generated by peacefulrobot-agents FOSS Security Assistance*